### PR TITLE
removed -j6 parameter from script file

### DIFF
--- a/scripts/compile-local.sh
+++ b/scripts/compile-local.sh
@@ -16,7 +16,7 @@ if [ "$COPYFOLDER" == "" ]; then
         git submodule update --init --recursive
     else
         echo "Cloning headunit-desktop from https://github.com/viktorgino/headunit-desktop.git"
-        git clone --recursive --depth 1 -j6 https://github.com/viktorgino/headunit-desktop.git
+        git clone --recursive --depth 1 https://github.com/viktorgino/headunit-desktop.git
     fi
 fi
 


### PR DESCRIPTION
Removing this parameter greatly opens up the compatibility of this program. It now can now be compiled and ran on Ubuntu 16.04 LTS as long as QT 5.x or greater is installed.