### PR TITLE
cmd line option to select plugins to load

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -6,6 +6,7 @@
 #include <QJsonObject>
 #include <QVariantList>
 #include <QQmlComponent>
+#include <QCommandLineParser>
 #include <QThreadPool>
 #include <QDir>
 #include <QSettings>
@@ -37,7 +38,27 @@ int main(int argc, char *argv[])
 
     int defaultMenuItem = 6;
 
-    PluginManager pluginManager(engine);
+    QCommandLineParser parser;
+    parser.setApplicationDescription("helper");
+    parser.addHelpOption();
+    parser.addVersionOption();
+    
+    QCommandLineOption pluginsOption(QStringList() << "p" << "plugins",
+	QCoreApplication::translate("main", "Plugins to enable (defaults to all)"),
+	QCoreApplication::translate("main", "plugins")
+    );
+    parser.addOption(pluginsOption);
+
+    parser.process(app);
+    QString p = parser.value(pluginsOption);
+    bool whitelist = parser.isSet(pluginsOption);
+    QStringList plugins;
+    if (whitelist) {
+	    plugins = p.split(" ",QString::SkipEmptyParts);
+    }
+   
+
+    PluginManager pluginManager(engine, whitelist, plugins);
     ThemeManager themeManager(engine);
     engine->rootContext()->setContextProperty("defaultMenuItem", defaultMenuItem);
 

--- a/app/pluginmanager.cpp
+++ b/app/pluginmanager.cpp
@@ -2,14 +2,14 @@
 
 Q_LOGGING_CATEGORY(PLUGINMANAGER, "Plugin Manager")
 
-PluginManager::PluginManager(QQmlApplicationEngine *engine, QObject *parent) : QObject(parent)
+PluginManager::PluginManager(QQmlApplicationEngine *engine, bool filter, QStringList filterList, QObject *parent) : QObject(parent)
 {
-    loadPlugins(engine);
+    loadPlugins(engine, filter, filterList);
 }
 void PluginManager::settingsChanged(QString key, QVariant value){
     qDebug () << "settingsChanged" << key << value;
 }
-bool PluginManager::loadPlugins(QQmlApplicationEngine *engine)
+bool PluginManager::loadPlugins(QQmlApplicationEngine *engine, bool filter, QStringList filterList)
 {
     QDir pluginsDir(qApp->applicationDirPath());
 #if defined(Q_OS_WIN)
@@ -25,6 +25,14 @@ bool PluginManager::loadPlugins(QQmlApplicationEngine *engine)
     pluginsDir.cd("plugins");
     //Load plugins
     foreach (QString fileName, pluginsDir.entryList(QDir::Files)) {
+
+	QString fileBaseName=fileName.section(".",0,0);
+	if (filter && !filterList.contains(fileBaseName,Qt::CaseInsensitive)) {
+		qDebug() << "Plugin not whitelisted (disabled): " << fileBaseName;
+		continue;
+	}
+	qDebug() << "Loading plugin: " << fileName;
+
         QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(fileName));
 
         if(pluginLoader.metaData().value("MetaData").type() != QJsonValue::Object){

--- a/app/pluginmanager.h
+++ b/app/pluginmanager.h
@@ -22,7 +22,7 @@ class PluginManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit PluginManager(QQmlApplicationEngine *engine, QObject *parent = nullptr);
+    explicit PluginManager(QQmlApplicationEngine *engine, bool filter, QStringList filterList, QObject *parent = nullptr);
     ~PluginManager();
 signals:
 
@@ -30,7 +30,7 @@ public slots:
 private slots:
     void messageReceived(QString id, QString message);
 private:
-    bool loadPlugins(QQmlApplicationEngine *engine);
+    bool loadPlugins(QQmlApplicationEngine *engine, bool filter, QStringList filterList);
     QVariantList menuItems;
     QVariantList configItems;
     QMap<QString, PluginInterface *> plugins;


### PR DESCRIPTION
We have different types of plugins and the list will only grow.

This patch enables user to select plugins to load.
![image](https://user-images.githubusercontent.com/161846/56493397-daf11880-64e6-11e9-8464-c7bf2af22b5a.png)

If omitted, all plugins will be loaded (the default behaviour).