### PR TITLE
VAAPI Support

### DIFF
--- a/modules/android-auto/headunit.cpp
+++ b/modules/android-auto/headunit.cpp
@@ -101,7 +101,7 @@ int Headunit::init(){
                                  "omxh264dec ! "
         #else
                                  /* Try Hardware VAAPI compatible decoding */
-				 "vaapih264dec low-latency=true !"
+				 "vaapih264dec low-latency=true ! "
         #endif
                 "appsink emit-signals=true sync=false name=vid_sink";
 

--- a/modules/android-auto/headunit.cpp
+++ b/modules/android-auto/headunit.cpp
@@ -101,7 +101,7 @@ int Headunit::init(){
                                  "omxh264dec ! "
         #else
                                  /* Try Hardware VAAPI compatible decoding */
-				 "vaapih264dec low-latency=true ! "
+				 "vaapih264dec low-latency=true ! vaapipostproc ! video/x-raw,format=YV12 ! "
         #endif
                 "appsink emit-signals=true sync=false name=vid_sink";
 


### PR DESCRIPTION
Support for VAAPI for hardware accelerated H264 decoding on platforms with a VAAPI compatible GPU (i.e. Intel).

Requires gstreamer1.0-vaapi and a VAAPI driver (intel-media-va-driver) be installed.

Will fall back to software decoding if VAAPI pipeline fails.

VAAPI decoder does not support YUV420P colorspace, hence the use of YV12
https://gstreamer.freedesktop.org/documentation/vaapi/vaapih264dec.html

Unsure if omxh264 can output to YV12 so have retained the use of YUV420P for the raspberry pi.
