### PR TITLE
Added null check to actionHandler()

### DIFF
--- a/app/pluginmanager.cpp
+++ b/app/pluginmanager.cpp
@@ -134,8 +134,11 @@ void PluginManager::actionHandler(QString sender, QString id, QVariant message){
 
         } else {
             PluginObject *pluginObject = m_pluginList.getPlugin(messageId[0]);
-
-            pluginObject->callAction(messageId[1], message);
+            if (pluginObject) {
+                pluginObject->callAction(messageId[1], message);
+            } else {
+                qWarning() << "actionHandler() : Could not get plugin " << messageId[0];
+            }
         }
     } else {
         qWarning () << "actionHandler() : Action Handler id";


### PR DESCRIPTION
actionHandler would cause a Segfault if a plugin sends an action to a plugin that has not been loaded or does not exist. This change reduces this to a warning.