### PR TITLE
Added systemd watchdog & notify compatiblity

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -4,6 +4,7 @@ QT += gui widgets qml quick
 CONFIG += c++11 link_pkgconfig welleio
 QMAKE_CXXFLAGS += -Wno-unused-parameter
 INCLUDEPATH += $${PWD}/includes
+LIBS += -lsystemd
 
 include("../config.pri")
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -14,6 +14,8 @@
 #include <QLoggingCategory>
 #include <unistd.h>
 #include <QElapsedTimer>
+#include <QTimer>
+#include <systemd/sd-daemon.h>
 
 #include "hudloader.h"
 
@@ -40,7 +42,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription("viktorgino's HeadUnit Desktop");
     parser.addHelpOption();
     parser.addVersionOption();
-    
+
     QCommandLineOption pluginsOption(QStringList() << "p" << "plugins",
 	QCoreApplication::translate("main", "Plugins to enable (defaults to all)"),
 	QCoreApplication::translate("main", "plugins")
@@ -67,6 +69,22 @@ int main(int argc, char *argv[])
     engine->rootContext()->setContextProperty("loader", &loader);
     qDebug("%lld ms : Loading theme loader", time.elapsed());
     engine->load(QUrl(QStringLiteral("qrc:/loader.qml")));
+
+    // If service Type=notify the service is only considered ready once we send this
+    sd_notify(0, "READY=1");
+
+    uint64_t watchdogIntervalUs = 0;
+    QTimer watchdogTimer;
+    QObject::connect(&watchdogTimer, &QTimer::timeout, [](){
+        sd_notify(0, "WATCHDOG=1");
+    });
+
+    // Service WatchdogSec must be set for this to return > 0
+    if (sd_watchdog_enabled(0, &watchdogIntervalUs) > 0) {
+        qDebug("Systemd watchdog is enabled with %lu us\n", watchdogIntervalUs);
+        // Recommended reporting interval is half the watchdog interval
+        watchdogTimer.start(watchdogIntervalUs / 2000);
+    }
 
     qDebug("%lld ms : Starting main loop", time.elapsed());
     int ret = app.exec();


### PR DESCRIPTION
The type of service for systemd can now be changed to Notify and a WatchdogSec can be set so that in the event the application freezes systemd will terminate and restart it.

Requires libsystemd-dev to be installed in order to compile ie sudo apt-get install libsystemd-dev